### PR TITLE
Add listening exercise generator and TTS synth module

### DIFF
--- a/controllers/listening/generate_exercise.py
+++ b/controllers/listening/generate_exercise.py
@@ -1,0 +1,15 @@
+import os
+from utils.GeneralPromptGen import generate_prompt_with_template
+
+
+def generate_listening_exercise(dynamic_block: str) -> str:
+    """Generate a listening exercise using a prompt template and dynamic block."""
+    current_dir = os.path.dirname(__file__)
+    template_path = os.path.join(current_dir, "listening_prompt.txt")
+    return generate_prompt_with_template(dynamic_block, template_path)
+
+
+if __name__ == "__main__":
+    print("🧪 Running test:")
+    test_block = "A short dialogue about ordering food at a restaurant. Include 3 questions."
+    print(generate_listening_exercise(test_block))

--- a/controllers/listening/listening_prompt.txt
+++ b/controllers/listening/listening_prompt.txt
@@ -1,0 +1,13 @@
+You are an English listening comprehension exercise generator for A2-level students.
+
+Given the topic or instructions below, craft a short audio script and three comprehension questions.
+
+Topic or instructions:
+{{DYNAMIC_BLOCK}}
+
+Return only JSON using this schema:
+{
+  "transcript": "60-80 word script for the audio.",
+  "questions": ["Question 1?", "Question 2?", "Question 3?"]
+}
+Do not include markdown or any extra commentary.

--- a/controllers/listening/synth.py
+++ b/controllers/listening/synth.py
@@ -1,0 +1,24 @@
+import os
+import openai
+
+
+client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def synthesize_text(text: str, voice: str = "alloy") -> bytes:
+    """Convert text to speech using an external TTS service and return audio bytes."""
+    with client.audio.speech.with_streaming_response.create(
+        model="gpt-4o-mini-tts",
+        voice=voice,
+        input=text
+    ) as response:
+        audio_bytes = b"".join(response.iter_bytes())
+    return audio_bytes
+
+
+if __name__ == "__main__":
+    print("🧪 Running test:")
+    sample_audio = synthesize_text("Hello, this is a test of the text to speech system.")
+    with open("sample_audio.mp3", "wb") as f:
+        f.write(sample_audio)
+    print("Sample audio written to sample_audio.mp3")


### PR DESCRIPTION
## Summary
- add listening exercise generator using prompt template
- rename Synth module to synth and implement TTS synthesis
- provide listening prompt template

## Testing
- `python -m py_compile controllers/listening/generate_exercise.py controllers/listening/synth.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689052f574b08325a3876b69cabc9d20